### PR TITLE
Simplify sample notebook a bit and change docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,14 @@ FROM jupyter/scipy-notebook:latest
 
 LABEL maintainer="Matthew Hanson <matt.a.hanson@gmail.com>"
 
-USER root
+USER ${NB_UID}
 
-RUN mamba install --yes \
-  cartopy==0.20.0 \
-  datacube==1.8.5 \
-  geopandas==0.9.0 \
-  pystac==1.1.0 \
-  pystac-client==0.3.0 \
-  coiled \
-  stackstac \
-  rasterio \
-  rioxarray \
-  hvplot; \
-  mamba clean --all -f -y;
+COPY environment.yaml /opt/conda/environment.yaml
+RUN mamba env update -p /opt/conda --file /opt/conda/environment.yaml \
+    && mamba clean --all -f -y
 
-# enable importing jupyter notebooks as modules
-RUN pip install geoviews odc-stac odc-algo planetary_computer geogif
+COPY dask.yaml /home/jovyan/.config/dask/dask.yaml
 
 ENV \
-  GDAL_DISABLE_READDIR_ON_OPEN=YES
+  GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
 
-USER ${NB_UID}

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ If you are only running notebooks that do NOT require AWS credentials (e.g. [not
 Then build the Docker container:
 
 ```
-$ docker compose build
+$ docker-compose build
 ```
 
 Then run using Docker compose:
 
 ```
-$ docker compose up
+$ docker-compose up
 ```
 
 After starting up the container it will print a local URL that can be copy and pasted into a browser.

--- a/dask.yaml
+++ b/dask.yaml
@@ -1,0 +1,11 @@
+temporary-directory: /tmp
+
+distributed:
+   dashboard:
+      link: "/proxy/{port}/status"
+   worker:
+      memory:
+        target: 0.95
+        spill: 0.99
+        pause: 0.99
+        terminate: 0.99

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       volumes:
         - ./:/home/jovyan/work
       ports:
-        - 8888:8888
-        - 8787:8787
-      entrypoint: jupyter notebook --allow-root --no-browser --ip=0.0.0.0
-
-
+        - 18888:18888
+      entrypoint: |
+        jupyter notebook --notebook-dir=work/notebooks --no-browser --ip=0.0.0.0 --port=18888

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,25 @@
+dependencies:
+  # Pin these as current cartopy struggles with shapely 1.8+
+  - cartopy==0.20.1
+  - shapely==1.7.1
+  - geopandas==0.10.2
+
+  - datacube==1.8.6
+  - pystac==1.1.0
+  - pystac-client==0.3.0
+  - odc-stac
+  - coiled
+  - stackstac
+  - rasterio
+  - rioxarray
+  - planetary-computer
+  - geoviews
+  - dask-image
+  - dask-labextension
+  - hvplot
+
+  - jupyter-server-proxy
+  - pip
+  - pip:
+      - odc-algo
+      - geogif

--- a/notebooks/odc-planetary-computer.ipynb
+++ b/notebooks/odc-planetary-computer.ipynb
@@ -134,12 +134,12 @@
     "import json\n",
     "\n",
     "aoi = gpd.read_file('../aois/bear-fire.geojson')\n",
-    "geom = json.loads(aoi['geometry'].to_json())['features'][0]['geometry']\n",
+    "geom = aoi['geometry'][0] # < shapely geometry object\n",
     "\n",
     "# limit sets the # of items per page so we can see multiple pages getting fetched\n",
     "search = cat.search(\n",
     "    collections = [\"sentinel-2-l2a\"],\n",
-    "    intersects = aoi['geometry'][0],\n",
+    "    intersects = geom,\n",
     "    datetime = \"2019-10-01/2019-10-31\",\n",
     "    query = [\"eo:cloud_cover<25\"],\n",
     "    limit = 100\n",
@@ -221,7 +221,7 @@
    "id": "9b912655",
    "metadata": {},
    "source": [
-    "Here we load as a DataCube. A PySTAC ItemCollection is created from the found STAC Items, and we specify various parameters, such as bands of interest and chunk size."
+    "Here we load as a DataCube. A PySTAC ItemCollection is created from the found STAC Items, and we specify various parameters, such as bands of interest and chunk size. We are requesting to only load pixels within a bounding box of the requested geometry (`bbox=geom.bounds`)."
    ]
   },
   {
@@ -241,20 +241,10 @@
     "# Create PySTAC ItemCollection\n",
     "item_collection = pystac.ItemCollection(items_dict)\n",
     "\n",
-    "# default to CRS and resolution from first Item\n",
-    "from pystac.extensions.projection import ProjectionExtension\n",
-    "from pyproj import CRS\n",
-    "\n",
-    "proj = ProjectionExtension.ext(item_collection[0])\n",
-    "output_crs = CRS.from_epsg(proj.epsg)\n",
-    "#resolution = (proj.transform[4], proj.transform[0])\n",
-    "resolution = (10, -10)\n",
-    "\n",
     "dc = stac_load(item_collection,\n",
     "               measurements=['B02', 'B03', 'B04', 'B08'],\n",
     "               chunks={\"x\": 2048, \"y\": 2048},\n",
-    "               output_crs=output_crs,\n",
-    "               resolution=resolution,\n",
+    "               bbox=geom.bounds,\n",
     "               stac_cfg=cfg,\n",
     "               patch_url=pc.sign\n",
     ")\n",
@@ -268,22 +258,7 @@
    "source": [
     "# Calculations\n",
     "\n",
-    "The datacube currently contains complete Items, we want to clip these to our geometry of interest. We will then also create an RGB datacube representation, and generate an NDVI datacube."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "32fc9e7f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "import rioxarray\n",
-    "\n",
-    "dc = dc.rio.clip([geom], crs='epsg:4326')\n",
-    "dc"
+    "We will create an RGBA datacube representation (`nodata` values have `alpha=0`), and generate an NDVI datacube."
    ]
   },
   {
@@ -307,8 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ndvi = ((dc['B08'] - dc['B04']) / (dc['B08'] + dc['B04'])).clip(0, 1)\n",
-    "ndvi.name = 'ndvi'\n",
+    "ndvi = ((dc['B08'] - dc['B04']) / (dc['B08'] + dc['B04'])).clip(0, 1).rename(\"ndvi\")\n",
     "ndvi"
    ]
   },
@@ -455,7 +429,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster.close()"
+    "if \"cluster\" in locals():\n",
+    "    cluster.close()"
    ]
   }
  ],


### PR DESCRIPTION
## Notebook changes

- Use auto-detection for CRS/resolution
- Use `bbox=` parameter directly at `stac_load` instead of `rioxarray.clip` afterwards

## Docker changes

- don't use root to install extra packages `/opt/conda` is not owned by root
- Use `mamba env update -f <yaml>` instead of `mamba install`
- Install things from `conda-forge` as much as possible
- Pin `shapely` to lower version make `cartopy/geopandas` work again
- Move notebook server to non-default port to avoid clashes with notebook people
  are likely running on their machine already
- Use `jupyter-server-proxy` instead of exposing an extra port for dask dashboard
- Configure dask dashboard link to go via `jupyter-server-proxy`
- Configure dask spill to go into `/tmp` and raise spill threshold
- Use older style `docker-compose` instead of newer `docker compose` in the docs (new one is backward compatible anyway as it includes docker-compose link)
- Start in the notebook folder

