### PR TITLE
Landast notebook fixups

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: odc
 channels:
   - conda-forge
 dependencies:
-  - python=3.9   # hvplot issues with 3.10
+  - python
   - ipykernel
   - cartopy
   - shapely
@@ -11,8 +11,7 @@ dependencies:
   - datacube
   - pystac
   - pystac-client
-  - odc-algo
-  - odc-stac
+  - odc-stac >= 0.3.1
   - coiled
   - stackstac
   - rasterio

--- a/notebooks/odc-landsat.ipynb
+++ b/notebooks/odc-landsat.ipynb
@@ -255,7 +255,7 @@
    "id": "08311f41",
    "metadata": {},
    "source": [
-    "Here we load as a DataCube. A PySTAC ItemCollection is created from the found STAC Items, and we specify various parameters, such as bands of interest and chunk size."
+    "Here we load as a DataCube. A PySTAC ItemCollection is created from the found STAC Items, and we specify various parameters, such as bands of interest, chunk size, and geometry to clip the data to."
    ]
   },
   {
@@ -278,17 +278,12 @@
     "from pystac.extensions.projection import ProjectionExtension\n",
     "from pyproj import CRS\n",
     "\n",
-    "proj = ProjectionExtension.ext(item_collection[0])\n",
-    "output_crs = CRS.from_epsg(proj.epsg)\n",
-    "resolution = (proj.transform[4], proj.transform[0])\n",
-    "\n",
     "dc = stac_load(item_collection,\n",
     "               bands=['red', 'blue', 'green', 'nir08'],\n",
     "               chunks={\"x\": 2048, \"y\": 2048},\n",
-    "               output_crs=output_crs,\n",
-    "               resolution=resolution,\n",
     "               groupby='solar_day',\n",
-    "               stac_cfg=cfg\n",
+    "               stac_cfg=cfg,\n",
+    "               geopolygon=geom,\n",
     ")\n",
     "dc"
    ]
@@ -300,22 +295,7 @@
    "source": [
     "# Calculations\n",
     "\n",
-    "The datacube currently contains complete Items, we want to clip these to our geometry of interest. We will then also create an RGB datacube representation, and generate an NDVI datacube."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e527e83f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "import rioxarray\n",
-    "\n",
-    "dc = dc.rio.clip([geom], crs='epsg:4326')\n",
-    "dc"
+    "We create an RGB datacube representation and generate an NDVI datacube."
    ]
   },
   {
@@ -325,9 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from odc.algo import to_rgba\n",
-    "\n",
-    "vis = to_rgba(dc, clamp=(1, 20000), bands=['red', 'green', 'blue'])\n",
+    "vis = dc.odc.to_rgba(vmin=1, vmax=20000, bands=['red', 'green', 'blue'])\n",
     "vis"
    ]
   },


### PR DESCRIPTION
Two small fixes to get the landsat notebook back up and running:
- Unpin python version in docker container
- Use a single float for resolution instead of a tuple

Note that you'll need `odc-stac >= v0.3.1` to pick up https://github.com/opendatacube/odc-stac/pull/77. Rebuilding your docker container _should_ do the trick.

cc @rsignell-usgs

## Related issues

- Closes #8