### PR TITLE
Ceil pystac version below 1.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - geopandas
   - geogif
   - datacube
-  - pystac
+  - pystac < 1.7 # avoid the projection extension version bump, which breaks odc-stac loading: https://github.com/opendatacube/odc-stac/issues/105
   - pystac-client
   - odc-stac >= 0.3.1
   - coiled


### PR DESCRIPTION
As described in https://github.com/opendatacube/odc-stac/issues/105, the bump in the projection version breaks the extension interface in **PySTAC**, which **odc-stac** uses to load the projection information. By keeping **PySTAC** below 1.7, we keep the old projection extension schema version. cc @rsignell-usgs can you check that this fixes things on your side?

- Closes #12